### PR TITLE
Note default branch and empty line in refs list

### DIFF
--- a/README.gemini
+++ b/README.gemini
@@ -15,6 +15,12 @@ The server must respond with the output of:
 
 `git for-each-ref --format=%(objectname) %(refname) refs/heads/`
 
+and with an optional line indicating the default branch (e.g. `master`) in this
+format:
+`@refs/heads/<branch> HEAD`
+
+and ending with an empty line.
+
 ## Fast Export
 
 `gemini://<domain>/<repo>.git?fast-export=<ref>`


### PR DESCRIPTION
Nice work making git-remote-gemini! I hope it helps people publish and collaborate more with git on Gemini. Here are some changes I propose regarding the list command.

The `list` command needs a blank line at the end (e.g. ending with `\n\n`) ([reference](https://www.git-scm.com/docs/gitremote-helpers#Documentation/gitremote-helpers.txt-emlistem)). I found the client would hang without that.

I changed my git default branch and found that cloning a git-remote-gemini repo would complete but result in `warning: remote HEAD refers to nonexistent ref, unable to checkout.` and no branch checked out. Adding a line to the refs list for the HEAD symref fixed this. So I suggest recommending git-remote-gemini servers to do that.

Would it better to specify it as a code example like is currently done? Here is an alternative wording for that purpose:
```
The server must respond with the output of:

`git for-each-ref --format=%(objectname) %(refname) refs/heads/`
`HEAD=$(git symbolic-ref -q HEAD) && `echo "@$HEAD HEAD"`
`echo`
```